### PR TITLE
Solves SJRK-13

### DIFF
--- a/src/js/storyTelling-story-storyEditor.js
+++ b/src/js/storyTelling-story-storyEditor.js
@@ -116,7 +116,6 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
         model: {
             languageFromSelect: "",
             languageFromInput: "",
-            otherSelected: false,
             templateTerms: {
                 storyTitleIdForLabel: "@expand:{that}.getLabelId(title)",
                 storyAuthorIdForLabel: "@expand:{that}.getLabelId(author)",

--- a/src/js/storyTelling-story-storyEditor.js
+++ b/src/js/storyTelling-story-storyEditor.js
@@ -75,11 +75,6 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
             "onTemplateRendered.fireOnControlsBound": {
                 "func": "{that}.events.onControlsBound.fire",
                 "priority": "last"
-            },
-            "onStoryListenToRequested.log": {
-                "this": "console",
-                "method": "log",
-                "args": ["{that}.model.language"]
             }
         },
         invokers: {

--- a/src/js/storyTelling-story-storyEditor.js
+++ b/src/js/storyTelling-story-storyEditor.js
@@ -67,11 +67,25 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
                 target: "language",
                 singleTransform: {
                     type: "fluid.transforms.condition",
-                    condition: "{that}.model.languageFromInput",
+                    condition: {
+                        transform: {
+                            type: "fluid.transforms.binaryOp",
+                            left: "{that}.model.languageFromInput",
+                            right: "",
+                            operator: "!=="
+                        }
+                    },//"{that}.model.languageFromInput",
                     true: "{that}.model.languageFromInput",
                     false: "{that}.model.languageFromSelect"
                 },
                 priority: 3
+            }
+        },
+        modelListeners: {
+            "languageFromSelect": {
+                "this": "console",
+                "method": "log",
+                "args": ["{that}.model.language", "{that}.model.languageFromInput", "{that}.model.languageFromSelect"]
             }
         },
         listeners: {
@@ -95,6 +109,11 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
             "onTemplateRendered.fireOnControlsBound": {
                 "func": "{that}.events.onControlsBound.fire",
                 "priority": "last"
+            },
+            "onStoryListenToRequested.log": {
+                "this": "console",
+                "method": "log",
+                "args": ["{that}.model.language"]
             }
         },
         invokers: {

--- a/src/js/storyTelling-story-storyEditor.js
+++ b/src/js/storyTelling-story-storyEditor.js
@@ -28,26 +28,8 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
             onEditorPreviousRequested: null
         },
         modelRelay: {
-            languageFromInputSetLanguageSelectToOther: {
-                source: "{that}.model.languageFromInput",
-                target: "{that}.model.languageFromSelect",
-                backward: {
-                    excludeSource: "*"
-                },
-                forward: {
-                    excludeSource: "init"
-                },
-                singleTransform: {
-                    type: "fluid.transforms.literalValue",
-                    input: "other"
-                },
-                priority: 2
-            },
             clearLanguageInputWhenNotOther: {
                 target: "{that}.model.languageFromInput",
-                backward: {
-                    excludeSource: "*"
-                },
                 singleTransform: {
                     type: "fluid.transforms.condition",
                     condition: {
@@ -58,34 +40,18 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
                             operator: "==="
                         }
                     },
-                    true: "{that}.model.languageFromInput",
+                    true: undefined,
                     false: ""
-                },
-                priority: 1
+                }
             },
             languageFromUiToModel: {
                 target: "language",
                 singleTransform: {
                     type: "fluid.transforms.condition",
-                    condition: {
-                        transform: {
-                            type: "fluid.transforms.binaryOp",
-                            left: "{that}.model.languageFromInput",
-                            right: "",
-                            operator: "!=="
-                        }
-                    },//"{that}.model.languageFromInput",
+                    condition: "{that}.model.languageFromInput",
                     true: "{that}.model.languageFromInput",
                     false: "{that}.model.languageFromSelect"
-                },
-                priority: 3
-            }
-        },
-        modelListeners: {
-            "languageFromSelect": {
-                "this": "console",
-                "method": "log",
-                "args": ["{that}.model.language", "{that}.model.languageFromInput", "{that}.model.languageFromSelect"]
+                }
             }
         },
         listeners: {
@@ -155,6 +121,7 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
         model: {
             languageFromSelect: "",
             languageFromInput: "",
+            otherSelected: false,
             templateTerms: {
                 storyTitleIdForLabel: "@expand:{that}.getLabelId(title)",
                 storyAuthorIdForLabel: "@expand:{that}.getLabelId(author)",

--- a/src/templates/storyEdit.handlebars
+++ b/src/templates/storyEdit.handlebars
@@ -37,7 +37,7 @@
     </div>
     <div>
         <!-- TODO: load the languages dynamically -->
-        <select name="" id="{{storyLanguageListIdForLabel}}" class="{{storyLanguageListClasses}}" onchange="console.log('A CHANGE: ' + this.value);">
+        <select name="" id="{{storyLanguageListIdForLabel}}" class="{{storyLanguageListClasses}}">
             <option value="" selected="selected">-- {{message_storyLanguageInputDefault}} --</option>\
             {{#each availableLanguages}}
                 <option value="{{@key}}">{{this}}</option>

--- a/src/templates/storyEdit.handlebars
+++ b/src/templates/storyEdit.handlebars
@@ -37,7 +37,7 @@
     </div>
     <div>
         <!-- TODO: load the languages dynamically -->
-        <select name="" id="{{storyLanguageListIdForLabel}}" class="{{storyLanguageListClasses}}">
+        <select name="" id="{{storyLanguageListIdForLabel}}" class="{{storyLanguageListClasses}}" onchange="console.log('A CHANGE: ' + this.value);">
             <option value="" selected="selected">-- {{message_storyLanguageInputDefault}} --</option>\
             {{#each availableLanguages}}
                 <option value="{{@key}}">{{this}}</option>

--- a/tests/js/storyTelling-story-storyEditorTests.js
+++ b/tests/js/storyTelling-story-storyEditorTests.js
@@ -59,7 +59,7 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
             },
             {
                 name: "Test language input relays",
-                expect: 8,
+                expect: 7,
                 sequence: [{
                     func: "sjrk.storyTelling.testUtils.changeFormElement",
                     args: ["{storyEditor}","storyLanguage","Esperanto"]
@@ -99,10 +99,6 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
                 {
                     func: "jqUnit.assertNotEquals",
                     args: ["Model languageFromInput value not relayed to languageFromSelect field", "{storyEditor}.model.languageFromInput", "{storyEditor}.model.languageFromSelect"]
-                },
-                {
-                    func: "jqUnit.assertEquals",
-                    args: ["Select field value updated", "{storyEditor}.model.languageFromSelect", "other"]
                 }]
             }]
         }]

--- a/tests/js/storyTelling-story-storyEditorTests.js
+++ b/tests/js/storyTelling-story-storyEditorTests.js
@@ -59,7 +59,7 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
             },
             {
                 name: "Test language input relays",
-                expect: 5,
+                expect: 8,
                 sequence: [{
                     func: "sjrk.storyTelling.testUtils.changeFormElement",
                     args: ["{storyEditor}","storyLanguage","Esperanto"]
@@ -71,7 +71,8 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
                 {
                     func: "jqUnit.assertNotEquals",
                     args: ["Model languageFromInput value not relayed to languageFromSelect field", "{storyEditor}.model.languageFromInput", "{storyEditor}.model.languageFromSelect"]
-                }, {
+                },
+                {
                     func: "sjrk.storyTelling.testUtils.changeFormElement",
                     args: ["{storyEditor}","storyLanguageList","fr-CA"]
                 },
@@ -86,6 +87,22 @@ https://raw.githubusercontent.com/waharnum/sjrk-storyTelling/master/LICENSE.txt
                 {
                     func: "jqUnit.assertNotEquals",
                     args: ["Model languageFromSelect value not relayed to languageFromInput field", "{storyEditor}.model.languageFromSelect", "{storyEditor}.model.languageFromInput"]
+                },
+                {
+                    func: "sjrk.storyTelling.testUtils.changeFormElement",
+                    args: ["{storyEditor}","storyLanguage","Interlingua"]
+                },
+                {
+                    func: "jqUnit.assertEquals",
+                    args: ["Model language value relayed from text input field", "{storyEditor}.model.languageFromInput", "{storyEditor}.model.language"]
+                },
+                {
+                    func: "jqUnit.assertNotEquals",
+                    args: ["Model languageFromInput value not relayed to languageFromSelect field", "{storyEditor}.model.languageFromInput", "{storyEditor}.model.languageFromSelect"]
+                },
+                {
+                    func: "jqUnit.assertEquals",
+                    args: ["Select field value updated", "{storyEditor}.model.languageFromSelect", "other"]
                 }]
             }]
         }]


### PR DESCRIPTION
Solved the issue by removing the model relay rule "languageFromInputSetLanguageSelectToOther". Upon considering the eventual user interactions, assuming the language input text box will be hidden and disabled unless the "other" option is selected from the drop-down, I concluded that there will not be a case where the user would enter something in the text box without already having "other" selected.

Once that relay rule was out of the way, the change event is occurring when expected. I also adjusted the storyEditor test to remove the check for "other" in the select element.